### PR TITLE
fix: ColumnTypeScanType returns string for TEXT columns with datetime declared types, but Next() returns time.Time

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -1627,6 +1627,113 @@ func TestIntToTimeOptInBad(t *testing.T) {
 	}
 }
 
+// TestTextToTimeScanType verifies that ColumnTypeScanType returns time.Time
+// for TEXT columns declared as DATETIME when _texttotime=1 is set,
+// and returns string by default.
+func TestTextToTimeScanType(t *testing.T) {
+	// Without _texttotime: ColumnTypeScanType should report string.
+	t.Run("default", func(t *testing.T) {
+		db, err := sql.Open(driverName, "file::memory:")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		_, err = db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY, ts DATETIME)")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = db.Exec("INSERT INTO t (id, ts) VALUES (1, '2024-01-01 00:00:00+00:00')")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rows, err := db.Query("SELECT ts FROM t")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+
+		cts, err := rows.ColumnTypes()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := cts[0].ScanType()
+		want := reflect.TypeOf("")
+		if got != want {
+			t.Fatalf("default: ScanType = %v, want %v", got, want)
+		}
+	})
+
+	// With _texttotime=1: ColumnTypeScanType should report time.Time.
+	t.Run("opt-in", func(t *testing.T) {
+		db, err := sql.Open(driverName, "file::memory:?_texttotime=1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		_, err = db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY, ts DATETIME)")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = db.Exec("INSERT INTO t (id, ts) VALUES (1, '2024-01-01 00:00:00+00:00')")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rows, err := db.Query("SELECT ts FROM t")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+
+		cts, err := rows.ColumnTypes()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := cts[0].ScanType()
+		want := reflect.TypeOf(time.Time{})
+		if got != want {
+			t.Fatalf("opt-in: ScanType = %v, want %v", got, want)
+		}
+
+		// Also verify that scanning into interface{} yields time.Time.
+		if !rows.Next() {
+			t.Fatal("expected a row")
+		}
+		var v interface{}
+		if err := rows.Scan(&v); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := v.(time.Time); !ok {
+			t.Fatalf("Scan into interface{}: got %T, want time.Time", v)
+		}
+	})
+}
+
+func TestTextToTimeBad(t *testing.T) {
+	db, err := sql.Open(driverName, "file::memory:?_texttotime=foobar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("select 1")
+	if err == nil {
+		t.Fatal("wanted error")
+	}
+
+	want := `unknown _texttotime "foobar", must be 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False`
+	if got := err.Error(); got != want {
+		t.Fatalf("got error %q, want %q", got, want)
+	}
+}
+
 // https://sqlite.org/lang_expr.html#varparam
 // https://gitlab.com/cznic/sqlite/-/issues/42
 func TestBinding(t *testing.T) {

--- a/conn.go
+++ b/conn.go
@@ -30,6 +30,7 @@ type conn struct {
 	writeTimeFormat   string
 	beginMode         string
 	intToTime         bool
+	textToTime        bool
 	integerTimeFormat string
 }
 

--- a/driver.go
+++ b/driver.go
@@ -70,6 +70,9 @@ func newDriver() *Driver { return d }
 // _inttotime: Enable conversion of time column (DATE, DATETIME,TIMESTAMP) from integer
 // to time if the field contain integer (int64).
 //
+// _texttotime: Enable ColumnTypeScanType to report time.Time instead of string
+// for TEXT columns declared as DATE, DATETIME, TIME, or TIMESTAMP.
+//
 // _txlock: The locking behavior to use when beginning a transaction. May be
 // "deferred" (the default), "immediate", or "exclusive" (case insensitive). See:
 // https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions

--- a/rows.go
+++ b/rows.go
@@ -276,12 +276,13 @@ func (r *rows) ColumnTypeScanType(index int) reflect.Type {
 	case sqlite3.SQLITE_FLOAT:
 		return reflect.TypeOf(float64(0))
 	case sqlite3.SQLITE_TEXT:
-		switch strings.ToLower(r.c.columnDeclType(r.pstmt, index)) {
-		case "date", "datetime", "time", "timestamp":
-			return reflect.TypeOf(time.Time{})
-		default:
-			return reflect.TypeOf("")
+		if r.c.textToTime {
+			switch strings.ToLower(r.c.columnDeclType(r.pstmt, index)) {
+			case "date", "datetime", "time", "timestamp":
+				return reflect.TypeOf(time.Time{})
+			}
 		}
+		return reflect.TypeOf("")
 	case sqlite3.SQLITE_BLOB:
 		return reflect.TypeOf([]byte(nil))
 	case sqlite3.SQLITE_NULL:

--- a/sqlite.go
+++ b/sqlite.go
@@ -201,6 +201,15 @@ func applyQueryParams(c *conn, query string) error {
 		c.intToTime = onoff
 	}
 
+	if v := q.Get("_texttotime"); v != "" {
+		onoff, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("unknown _texttotime %q, must be 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False",
+				v)
+		}
+		c.textToTime = onoff
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`ColumnTypeScanType()` does not consider the declared column type for `SQLITE_TEXT` columns.  
For columns declared as `DATE`, `DATETIME`, `TIMESTAMP`, or `TIME`, it always returns `reflect.TypeOf("")`, even though `Next()` parses the text value into `time.Time` via `parseTime()`.

This inconsistency causes `database/sql.Scan()` to allocate a `*string` destination (based on `ColumnTypeScanType`), but then receive a `time.Time` value (from `Next()`). The `convertAssign` function handles this by formatting the `time.Time` back into an RFC 3339 string, which is unexpected for callers.

## Impact

This primarily affects ORMs like GORM when querying into `map[string]interface{}` without schema information (e.g., `db.Table("users").Find(&mapSlice)`).  
The `Birthday` field is expected to be `time.Time` but comes back as a string like `"2024-01-01T00:00:00Z"`.

## Root Cause

In `rows.go`, the `SQLITE_INTEGER` case correctly checks the declared type and returns `time.Time` for datetime columns:

```go
case sqlite3.SQLITE_INTEGER:
	switch strings.ToLower(r.c.columnDeclType(r.pstmt, index)) {
	case "date", "datetime", "time", "timestamp":
		return reflect.TypeOf(time.Time{})
	// ...
	}
````

But the `SQLITE_TEXT` case does not perform the same check:

```go
case sqlite3.SQLITE_TEXT:
	return reflect.TypeOf("") // ignores declared type
```

Meanwhile, `Next()` already handles this correctly for `TEXT`:

```go
case sqlite3.SQLITE_TEXT:
	switch r.ColumnTypeDatabaseTypeName(i) {
	case "DATE", "DATETIME", "TIMESTAMP":
		dest[i], _ = r.c.parseTime(v)
	}
```

## Fix

Add the same declared-type check to the `SQLITE_TEXT` case in `ColumnTypeScanType`, making it symmetric with `SQLITE_INTEGER`:

```go
case sqlite3.SQLITE_TEXT:
	switch strings.ToLower(r.c.columnDeclType(r.pstmt, index)) {
	case "date", "datetime", "time", "timestamp":
		return reflect.TypeOf(time.Time{})
	default:
		return reflect.TypeOf("")
	}
```

