### PR TITLE
sqlite: expose defensive mode DSN option

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -83,6 +83,10 @@ func newConn(dsn string) (*conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	defensiveMode, err := getDefensiveMode(query)
+	if err != nil {
+		return nil, err
+	}
 	c := &conn{tls: libc.NewTLS(), errorRcMode: errorRcMode}
 	// The withOpenGate wrapper marks the page-cache opened flag and holds
 	// pcacheState.openGate.RLock for the duration of sqlite3_open_v2, so
@@ -123,10 +127,16 @@ func newConn(dsn string) (*conn, error) {
 	defer libc.Xfree(c.tls, zMain)
 	c.inMemory = libc.GoString(sqlite3.Xsqlite3_db_filename(c.tls, c.db, zMain)) == ""
 
-	// _dqs is applied before applyQueryParams because the SQLite contract
+	// Connection-level sqlite3_db_config options are applied before
+	// applyQueryParams because the SQLite contract
 	// requires sqlite3_db_config(SQLITE_DBCONFIG_DQS_*) to be set before
 	// any statement is prepared on the connection. applyQueryParams runs
 	// user-supplied PRAGMA statements, so it must come after.
+	if err = applyDefensiveConfig(c, defensiveMode); err != nil {
+		c.Close()
+		return nil, err
+	}
+
 	if err = applyDQSConfig(c, query); err != nil {
 		c.Close()
 		return nil, err

--- a/defensive_test.go
+++ b/defensive_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 The Sqlite Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+func TestDefensiveConfigCallVaList(t *testing.T) {
+	c, err := newConn(":memory:")
+	if err != nil {
+		t.Fatalf("newConn: %v", err)
+	}
+	defer c.Close()
+
+	if rc := c.dbConfigBool(sqlite3.SQLITE_DBCONFIG_DEFENSIVE, true); rc != sqlite3.SQLITE_OK {
+		t.Fatalf("enable defensive mode = %d, want SQLITE_OK", rc)
+	}
+	if rc := c.dbConfigBool(sqlite3.SQLITE_DBCONFIG_DEFENSIVE, false); rc != sqlite3.SQLITE_OK {
+		t.Fatalf("disable defensive mode = %d, want SQLITE_OK", rc)
+	}
+}
+
+func TestDefensiveDSNValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{"invalid", "?_defensive=not-a-bool&_pragma=schema_version(41)", "invalid _defensive"},
+		{"empty", "?_defensive=&_pragma=schema_version(41)", "invalid _defensive"},
+		{"duplicate_same", "?_defensive=1&_defensive=1&_pragma=schema_version(41)", "exactly once"},
+		{"duplicate_conflicting", "?_defensive=1&_defensive=0&_pragma=schema_version(41)", "exactly once"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "invalid.db")
+			db, err := sql.Open("sqlite", dbPath+tc.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			err = db.Ping()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Ping error = %v, want substring %q", err, tc.want)
+			}
+			if _, statErr := os.Stat(dbPath); !os.IsNotExist(statErr) {
+				t.Fatalf("invalid DSN created database before rejection: stat error=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestDefensiveModeBlocksDangerousOperations(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "defensive.db")
+	db, err := sql.Open("sqlite", dbPath+"?_defensive=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("CREATE TABLE protected(id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatal(err)
+	}
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode=OFF").Scan(&journalMode); err != nil {
+		t.Fatal(err)
+	}
+	if strings.EqualFold(journalMode, "off") {
+		t.Fatalf("defensive connection entered forbidden journal_mode=%q", journalMode)
+	}
+
+	var before, after int64
+	if err := db.QueryRow("PRAGMA schema_version").Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA schema_version=%d", before+41)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow("PRAGMA schema_version").Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("schema_version changed under defensive mode: before=%d after=%d", before, after)
+	}
+
+	if _, err := db.Exec("PRAGMA writable_schema=ON"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("DELETE FROM sqlite_schema WHERE name='protected'"); err == nil {
+		t.Fatal("direct sqlite_schema write unexpectedly succeeded under defensive mode")
+	}
+	var protectedCount int
+	if err := db.QueryRow("SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='protected'").Scan(&protectedCount); err != nil {
+		t.Fatal(err)
+	}
+	if protectedCount != 1 {
+		t.Fatalf("protected schema row changed after rejected write: count=%d", protectedCount)
+	}
+}
+
+func TestDefensiveModeAppliesBeforeUserPragma(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ordering.db")
+	db, err := sql.Open("sqlite", dbPath+"?_defensive=1&_pragma=journal_mode(OFF)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatal(err)
+	}
+	if strings.EqualFold(journalMode, "off") {
+		t.Fatalf("user PRAGMA ran before defensive mode: journal_mode=%q", journalMode)
+	}
+}
+
+func TestDefensiveModeAppliesToEveryPhysicalConnection(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pool.db")
+	db, err := sql.Open("sqlite", dbPath+"?_defensive=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(4)
+
+	ctx := context.Background()
+	connections := make([]*sql.Conn, 0, 4)
+	defer func() {
+		for _, c := range connections {
+			_ = c.Close()
+		}
+	}()
+	for i := 0; i < 4; i++ {
+		c, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("Conn(%d): %v", i, err)
+		}
+		connections = append(connections, c)
+	}
+	for i, c := range connections {
+		var before, after int64
+		if err := c.QueryRowContext(ctx, "PRAGMA schema_version").Scan(&before); err != nil {
+			t.Fatalf("connection %d: %v", i, err)
+		}
+		if _, err := c.ExecContext(ctx, fmt.Sprintf("PRAGMA schema_version=%d", before+41)); err != nil {
+			t.Fatalf("connection %d: %v", i, err)
+		}
+		if err := c.QueryRowContext(ctx, "PRAGMA schema_version").Scan(&after); err != nil {
+			t.Fatalf("connection %d: %v", i, err)
+		}
+		if after != before {
+			t.Fatalf("connection %d changed schema_version under defensive mode: before=%d after=%d", i, before, after)
+		}
+	}
+}
+
+func TestUnprotectedPoolIsANegativeControl(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pool-control.db")
+	db, err := sql.Open("sqlite", dbPath+"?_defensive=0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(4)
+
+	ctx := context.Background()
+	connections := make([]*sql.Conn, 0, 4)
+	defer func() {
+		for _, c := range connections {
+			_ = c.Close()
+		}
+	}()
+	for i := 0; i < 4; i++ {
+		c, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("Conn(%d): %v", i, err)
+		}
+		connections = append(connections, c)
+	}
+	for i, c := range connections {
+		var before, after int64
+		if err := c.QueryRowContext(ctx, "PRAGMA schema_version").Scan(&before); err != nil {
+			t.Fatalf("connection %d: %v", i, err)
+		}
+		if _, err := c.ExecContext(ctx, fmt.Sprintf("PRAGMA schema_version=%d", before+1)); err != nil {
+			t.Fatalf("connection %d negative control: %v", i, err)
+		}
+		if err := c.QueryRowContext(ctx, "PRAGMA schema_version").Scan(&after); err != nil {
+			t.Fatalf("connection %d: %v", i, err)
+		}
+		if after != before+1 {
+			t.Fatalf("connection %d negative control did not mutate schema_version: before=%d after=%d", i, before, after)
+		}
+	}
+}
+
+func TestDefensiveBooleanForms(t *testing.T) {
+	for _, value := range []string{"1", "true", "TRUE", "t"} {
+		t.Run("on_"+value, func(t *testing.T) {
+			db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "on.db")+"?_defensive="+value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			var before, after int64
+			if err := db.QueryRow("PRAGMA schema_version").Scan(&before); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.Exec(fmt.Sprintf("PRAGMA schema_version=%d", before+41)); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.QueryRow("PRAGMA schema_version").Scan(&after); err != nil {
+				t.Fatal(err)
+			}
+			if after != before {
+				t.Fatalf("true form %q failed to protect schema_version", value)
+			}
+		})
+	}
+}
+
+func TestUnmodifiedBehaviorIsNotAnADEDefensiveControl(t *testing.T) {
+	for _, suffix := range []string{"", "?_defensive=0", "?_defensive=false", "?_defensive=FALSE", "?_defensive=f"} {
+		t.Run(suffix, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "negative-control.db")
+			db, err := sql.Open("sqlite", dbPath+suffix)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			var before, after int64
+			if err := db.QueryRow("PRAGMA schema_version").Scan(&before); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.Exec(fmt.Sprintf("PRAGMA schema_version=%d", before+41)); err != nil {
+				t.Fatalf("negative control unexpectedly rejected schema_version write: %v", err)
+			}
+			if err := db.QueryRow("PRAGMA schema_version").Scan(&after); err != nil {
+				t.Fatal(err)
+			}
+			if after != before+41 {
+				t.Fatalf("negative control did not demonstrate baseline behavior: before=%d after=%d", before, after)
+			}
+		})
+	}
+}

--- a/driver.go
+++ b/driver.go
@@ -140,6 +140,13 @@ func newDriver() *Driver { return d }
 // https://www.sqlite.org/quirks.html#dblquote and
 // https://gitlab.com/cznic/sqlite/-/issues/61
 //
+// _defensive: Opt-in toggle for SQLite's defensive connection mode. Accepts
+// the values strconv.ParseBool understands. When true, the driver calls
+// sqlite3_db_config(SQLITE_DBCONFIG_DEFENSIVE) before any user-supplied PRAGMA
+// or statement is prepared. Duplicate or invalid values fail connection
+// creation. Absence or false preserves SQLite's default behavior. See:
+// https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+//
 // _error_rc: Opt-in error-string reporting mode for synthesised errors.
 // Accepts the values strconv.ParseBool understands ("0"/"1",
 // "false"/"true", "f"/"t", case-insensitive). When absent or set to a

--- a/sqlite.go
+++ b/sqlite.go
@@ -174,6 +174,46 @@ func applyDQSConfig(c *conn, query string) error {
 	return nil
 }
 
+// getDefensiveMode validates the _defensive DSN query parameter before
+// sqlite3_open_v2 can create or mutate a database. Absence or a false value
+// preserves SQLite's default behavior for backwards compatibility.
+//
+// The parameter is intentionally single-valued. Accepting duplicate values
+// would make the security posture depend on url.Values.Get choosing the first
+// value, so duplicates fail the connection before any query parameter is
+// applied.
+func getDefensiveMode(query string) (bool, error) {
+	q, err := url.ParseQuery(query)
+	if err != nil {
+		return false, err
+	}
+	values, ok := q["_defensive"]
+	if !ok {
+		return false, nil
+	}
+	if len(values) != 1 {
+		return false, fmt.Errorf("_defensive must be specified exactly once, got %d values", len(values))
+	}
+	on, err := strconv.ParseBool(values[0])
+	if err != nil {
+		return false, fmt.Errorf("invalid _defensive value %q: %w", values[0], err)
+	}
+	return on, nil
+}
+
+// applyDefensiveConfig enables SQLite's defensive connection mode after
+// sqlite3_open_v2 and before any user-supplied PRAGMA or statement can run.
+// See https://www.sqlite.org/c3ref/c_dbconfig_defensive.html.
+func applyDefensiveConfig(c *conn, on bool) error {
+	if !on {
+		return nil
+	}
+	if rc := c.dbConfigBool(sqlite3.SQLITE_DBCONFIG_DEFENSIVE, true); rc != sqlite3.SQLITE_OK {
+		return fmt.Errorf("sqlite3_db_config(SQLITE_DBCONFIG_DEFENSIVE, on) returned %d", rc)
+	}
+	return nil
+}
+
 // getErrorRcMode reads the _error_rc DSN query parameter and returns
 // the parsed boolean. Called from newConn before sqlite3_open_v2 so
 // open-time failures get the conditional errmsg treatment too: the


### PR DESCRIPTION
## Summary

- add a public `_defensive` DSN option that invokes `SQLITE_DBCONFIG_DEFENSIVE`
- validate the option before `sqlite3_open_v2`, then apply it before `_dqs` and user `_pragma` parameters
- reject invalid or duplicate values and require `SQLITE_OK`
- cover dangerous operations, initialization order, four physical connections, lazy-open rejection, and opt-out negative controls

## Compatibility

Absence or false preserves existing driver behavior. This branch is intentionally based on the v1.55.0 commit `cfb97341944de3bfa93dd4d7ef30bc921e924229`, which is the downstream governed baseline; maintainers may prefer to rebase or cherry-pick the single commit onto current master.

## Local verification

- Go 1.26.5 windows/amd64
- `GOTOOLCHAIN=local`, `GOWORK=off`, `CGO_ENABLED=0`
- `go mod tidy -diff`: PASS
- `go mod verify`: PASS
- targeted defensive tests: PASS

The existing root `TestConcurrentGoroutines` recursively requests `-race`, which is incompatible with the downstream CGO-disabled lane and is excluded from that lane's full-suite run.